### PR TITLE
sysprop: Use 'release-keys' for build tag

### DIFF
--- a/core/sysprop.mk
+++ b/core/sysprop.mk
@@ -148,7 +148,7 @@ endif
 # Both of these tags will be removed and replaced with "release-keys"
 # when the target-files is signed in a post-build step.
 ifeq ($(DEFAULT_SYSTEM_DEV_CERTIFICATE),build/make/target/product/security/testkey)
-BUILD_KEYS := test-keys
+BUILD_KEYS := release-keys
 else
 BUILD_KEYS := dev-keys
 endif


### PR DESCRIPTION
Change for build system. 

Test: Compile, install to device. Booted, changed test-keys to release-keys.
As result we get: SD1A.210817.036.A8 release-keys