### PR TITLE
[FIXME]build: Enable MODULE_BUILD_FROM_SOURE even if the apex is preb…

### DIFF
--- a/core/android_soong_config_vars.mk
+++ b/core/android_soong_config_vars.mk
@@ -111,9 +111,10 @@ endif
 
 ifneq (,$(ART_MODULE_BUILD_FROM_SOURCE))
   # Keep an explicit setting.
-else ifneq (,$(findstring .android.art,$(TARGET_BUILD_APPS)))
+else ifdef MODULE_BUILD_FROM_SOURCE
   # Build ART modules from source if they are listed in TARGET_BUILD_APPS.
   ART_MODULE_BUILD_FROM_SOURCE := true
+  OPTIONAL_MODULE_BUILD_FROM_SOURCE := true
 else
   # Do the same as other modules by default.
   ART_MODULE_BUILD_FROM_SOURCE := $(MODULE_BUILD_FROM_SOURCE)
@@ -131,14 +132,14 @@ INDIVIDUALLY_TOGGLEABLE_PREBUILT_MODULES := \
 
 $(foreach m, $(INDIVIDUALLY_TOGGLEABLE_PREBUILT_MODULES),\
   $(if $(call soong_config_get,$(m)_module,source_build),,\
-    $(call soong_config_set,$(m)_module,source_build,$(MODULE_BUILD_FROM_SOURCE))))
+    $(call soong_config_set,$(m)_module,source_build,$(OPTIONAL_MODULE_BUILD_FROM_SOURCE))))
 
 # Apex build mode variables
 ifdef APEX_BUILD_FOR_PRE_S_DEVICES
 $(call add_soong_config_var_value,ANDROID,library_linking_strategy,prefer_static)
 endif
 
-ifeq (true,$(MODULE_BUILD_FROM_SOURCE))
+ifdef MODULE_BUILD_FROM_SOURCE
 $(call add_soong_config_var_value,ANDROID,module_build_from_source,true)
 endif
 


### PR DESCRIPTION
…uilt

This is a temporary and hacky solutions, a proper way to fix this will be pushed
later down the line, however this does not affect UX or the final build in any way.

Signed-off-by: Dyneteve <dyneteve@hentaios.com>

This is Required commit for make it build/work Google's prebuilt apex