### PR TITLE
build: target: Move TeleService to telephony_system.mk

### DIFF
--- a/target/product/handheld_system.mk
+++ b/target/product/handheld_system.mk
@@ -65,7 +65,6 @@ PRODUCT_PACKAGES += \
     SimAppDialog \
     Telecom \
     TelephonyProvider \
-    TeleService \
     UserDictionaryProvider \
     VpnDialogs \
     vr \

--- a/target/product/telephony_system.mk
+++ b/target/product/telephony_system.mk
@@ -23,5 +23,6 @@ PRODUCT_PACKAGES := \
     CallLogBackup \
     com.android.cellbroadcast \
     CellBroadcastLegacyApp \
+    TeleService
 
 PRODUCT_COPY_FILES := \


### PR DESCRIPTION
- For Wifi-Only tablets, TeleService just adds 'No Service' on lockscreen and it looks bad.
- Doesn't affect phones as they will use full_base_telephony, which includes telephony.mk
- No issues on tablets as well
   - Ref: https://github.com/TrebleDroid/device_phh_treble/blob/f5e7b14838750df41d9298dcd2a34a68ab79d4ba/remove-telephony.sh#L7